### PR TITLE
Fix transition for single digit

### DIFF
--- a/Sources/MovingNumbersView/MovingNumbersView.swift
+++ b/Sources/MovingNumbersView/MovingNumbersView.swift
@@ -87,11 +87,18 @@ public struct MovingNumbersView<Element: View>: View {
         }
         
         // All elements are by default vertically centered
+        let applyTransition = !(numberOfDecimalPlaces == 0 && allElements.count == 1)
+
         let finalResultView = HStack(alignment: .center, spacing: 0) {
             ForEach(allElements) { (element) in
-                self.viewFromElement(element)
-                    .transition(self.elementTransition)
-                    .animation(self.digitStackAnimation)
+                if applyTransition {
+                    self.viewFromElement(element)
+                        .transition(self.elementTransition)
+                        .animation(self.digitStackAnimation)
+                } else {
+                    self.viewFromElement(element)
+                        .animation(self.digitStackAnimation)
+                }
             }
         }
         .frame(width: fixedWidth, alignment: .leading)


### PR DESCRIPTION
## Summary
- avoid applying insertion transition when displaying a single digit integer

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686afe3d80188323959b339cfe5f2545